### PR TITLE
Create Commons target and fixing typing error

### DIFF
--- a/Commons/Commons.xcodeproj/project.pbxproj
+++ b/Commons/Commons.xcodeproj/project.pbxproj
@@ -7,154 +7,154 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1A58F57023367973002F459C /* Netwroking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58F56623367973002F459C /* Netwroking.framework */; };
-		1A58F57523367973002F459C /* NetwrokingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A58F57423367973002F459C /* NetwrokingTests.swift */; };
-		1A58F57723367973002F459C /* Netwroking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A58F56923367973002F459C /* Netwroking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A58F59923367D01002F459C /* Commons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58F58F23367D01002F459C /* Commons.framework */; };
+		1A58F59E23367D01002F459C /* CommonsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A58F59D23367D01002F459C /* CommonsTests.swift */; };
+		1A58F5A023367D01002F459C /* Commons.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A58F59223367D01002F459C /* Commons.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		1A58F57123367973002F459C /* PBXContainerItemProxy */ = {
+		1A58F59A23367D01002F459C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1A58F55D23367973002F459C /* Project object */;
+			containerPortal = 1A58F58623367D00002F459C /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1A58F56523367973002F459C;
-			remoteInfo = Netwroking;
+			remoteGlobalIDString = 1A58F58E23367D01002F459C;
+			remoteInfo = Commons;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1A58F56623367973002F459C /* Netwroking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Netwroking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1A58F56923367973002F459C /* Netwroking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Netwroking.h; sourceTree = "<group>"; };
-		1A58F56A23367973002F459C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1A58F56F23367973002F459C /* NetwrokingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NetwrokingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		1A58F57423367973002F459C /* NetwrokingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetwrokingTests.swift; sourceTree = "<group>"; };
-		1A58F57623367973002F459C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A58F58F23367D01002F459C /* Commons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A58F59223367D01002F459C /* Commons.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Commons.h; sourceTree = "<group>"; };
+		1A58F59323367D01002F459C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A58F59823367D01002F459C /* CommonsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CommonsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A58F59D23367D01002F459C /* CommonsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonsTests.swift; sourceTree = "<group>"; };
+		1A58F59F23367D01002F459C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		1A58F56323367973002F459C /* Frameworks */ = {
+		1A58F58C23367D01002F459C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1A58F56C23367973002F459C /* Frameworks */ = {
+		1A58F59523367D01002F459C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A58F57023367973002F459C /* Netwroking.framework in Frameworks */,
+				1A58F59923367D01002F459C /* Commons.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1A58F55C23367973002F459C = {
+		1A58F58523367D00002F459C = {
 			isa = PBXGroup;
 			children = (
-				1A58F56823367973002F459C /* Netwroking */,
-				1A58F57323367973002F459C /* NetwrokingTests */,
-				1A58F56723367973002F459C /* Products */,
+				1A58F59123367D01002F459C /* Commons */,
+				1A58F59C23367D01002F459C /* CommonsTests */,
+				1A58F59023367D01002F459C /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		1A58F56723367973002F459C /* Products */ = {
+		1A58F59023367D01002F459C /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				1A58F56623367973002F459C /* Netwroking.framework */,
-				1A58F56F23367973002F459C /* NetwrokingTests.xctest */,
+				1A58F58F23367D01002F459C /* Commons.framework */,
+				1A58F59823367D01002F459C /* CommonsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		1A58F56823367973002F459C /* Netwroking */ = {
+		1A58F59123367D01002F459C /* Commons */ = {
 			isa = PBXGroup;
 			children = (
-				1A58F56923367973002F459C /* Netwroking.h */,
-				1A58F56A23367973002F459C /* Info.plist */,
+				1A58F59223367D01002F459C /* Commons.h */,
+				1A58F59323367D01002F459C /* Info.plist */,
 			);
-			path = Netwroking;
+			path = Commons;
 			sourceTree = "<group>";
 		};
-		1A58F57323367973002F459C /* NetwrokingTests */ = {
+		1A58F59C23367D01002F459C /* CommonsTests */ = {
 			isa = PBXGroup;
 			children = (
-				1A58F57423367973002F459C /* NetwrokingTests.swift */,
-				1A58F57623367973002F459C /* Info.plist */,
+				1A58F59D23367D01002F459C /* CommonsTests.swift */,
+				1A58F59F23367D01002F459C /* Info.plist */,
 			);
-			path = NetwrokingTests;
+			path = CommonsTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1A58F56123367973002F459C /* Headers */ = {
+		1A58F58A23367D01002F459C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A58F57723367973002F459C /* Netwroking.h in Headers */,
+				1A58F5A023367D01002F459C /* Commons.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1A58F56523367973002F459C /* Netwroking */ = {
+		1A58F58E23367D01002F459C /* Commons */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1A58F57A23367973002F459C /* Build configuration list for PBXNativeTarget "Netwroking" */;
+			buildConfigurationList = 1A58F5A323367D01002F459C /* Build configuration list for PBXNativeTarget "Commons" */;
 			buildPhases = (
-				1A58F56123367973002F459C /* Headers */,
-				1A58F56223367973002F459C /* Sources */,
-				1A58F56323367973002F459C /* Frameworks */,
-				1A58F56423367973002F459C /* Resources */,
+				1A58F58A23367D01002F459C /* Headers */,
+				1A58F58B23367D01002F459C /* Sources */,
+				1A58F58C23367D01002F459C /* Frameworks */,
+				1A58F58D23367D01002F459C /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = Netwroking;
-			productName = Netwroking;
-			productReference = 1A58F56623367973002F459C /* Netwroking.framework */;
+			name = Commons;
+			productName = Commons;
+			productReference = 1A58F58F23367D01002F459C /* Commons.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		1A58F56E23367973002F459C /* NetwrokingTests */ = {
+		1A58F59723367D01002F459C /* CommonsTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1A58F57D23367973002F459C /* Build configuration list for PBXNativeTarget "NetwrokingTests" */;
+			buildConfigurationList = 1A58F5A623367D01002F459C /* Build configuration list for PBXNativeTarget "CommonsTests" */;
 			buildPhases = (
-				1A58F56B23367973002F459C /* Sources */,
-				1A58F56C23367973002F459C /* Frameworks */,
-				1A58F56D23367973002F459C /* Resources */,
+				1A58F59423367D01002F459C /* Sources */,
+				1A58F59523367D01002F459C /* Frameworks */,
+				1A58F59623367D01002F459C /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				1A58F57223367973002F459C /* PBXTargetDependency */,
+				1A58F59B23367D01002F459C /* PBXTargetDependency */,
 			);
-			name = NetwrokingTests;
-			productName = NetwrokingTests;
-			productReference = 1A58F56F23367973002F459C /* NetwrokingTests.xctest */;
+			name = CommonsTests;
+			productName = CommonsTests;
+			productReference = 1A58F59823367D01002F459C /* CommonsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		1A58F55D23367973002F459C /* Project object */ = {
+		1A58F58623367D00002F459C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
 				ORGANIZATIONNAME = "José Victor Pereira Costa";
 				TargetAttributes = {
-					1A58F56523367973002F459C = {
+					1A58F58E23367D01002F459C = {
 						CreatedOnToolsVersion = 11.0;
 					};
-					1A58F56E23367973002F459C = {
+					1A58F59723367D01002F459C = {
 						CreatedOnToolsVersion = 11.0;
 					};
 				};
 			};
-			buildConfigurationList = 1A58F56023367973002F459C /* Build configuration list for PBXProject "Netwroking" */;
+			buildConfigurationList = 1A58F58923367D00002F459C /* Build configuration list for PBXProject "Commons" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -162,26 +162,26 @@
 				en,
 				Base,
 			);
-			mainGroup = 1A58F55C23367973002F459C;
-			productRefGroup = 1A58F56723367973002F459C /* Products */;
+			mainGroup = 1A58F58523367D00002F459C;
+			productRefGroup = 1A58F59023367D01002F459C /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				1A58F56523367973002F459C /* Netwroking */,
-				1A58F56E23367973002F459C /* NetwrokingTests */,
+				1A58F58E23367D01002F459C /* Commons */,
+				1A58F59723367D01002F459C /* CommonsTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		1A58F56423367973002F459C /* Resources */ = {
+		1A58F58D23367D01002F459C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1A58F56D23367973002F459C /* Resources */ = {
+		1A58F59623367D01002F459C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -191,33 +191,33 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		1A58F56223367973002F459C /* Sources */ = {
+		1A58F58B23367D01002F459C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1A58F56B23367973002F459C /* Sources */ = {
+		1A58F59423367D01002F459C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A58F57523367973002F459C /* NetwrokingTests.swift in Sources */,
+				1A58F59E23367D01002F459C /* CommonsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1A58F57223367973002F459C /* PBXTargetDependency */ = {
+		1A58F59B23367D01002F459C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 1A58F56523367973002F459C /* Netwroking */;
-			targetProxy = 1A58F57123367973002F459C /* PBXContainerItemProxy */;
+			target = 1A58F58E23367D01002F459C /* Commons */;
+			targetProxy = 1A58F59A23367D01002F459C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		1A58F57823367973002F459C /* Debug */ = {
+		1A58F5A123367D01002F459C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -268,7 +268,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -280,7 +280,7 @@
 			};
 			name = Debug;
 		};
-		1A58F57923367973002F459C /* Release */ = {
+		1A58F5A223367D01002F459C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -325,7 +325,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -337,7 +337,7 @@
 			};
 			name = Release;
 		};
-		1A58F57B23367973002F459C /* Debug */ = {
+		1A58F5A423367D01002F459C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -346,14 +346,14 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Netwroking/Info.plist;
+				INFOPLIST_FILE = Commons/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jvpc.Netwroking;
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.Commons;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -361,7 +361,7 @@
 			};
 			name = Debug;
 		};
-		1A58F57C23367973002F459C /* Release */ = {
+		1A58F5A523367D01002F459C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -370,14 +370,14 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Netwroking/Info.plist;
+				INFOPLIST_FILE = Commons/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jvpc.Netwroking;
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.Commons;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -385,36 +385,36 @@
 			};
 			name = Release;
 		};
-		1A58F57E23367973002F459C /* Debug */ = {
+		1A58F5A723367D01002F459C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 77FV36N6JL;
-				INFOPLIST_FILE = NetwrokingTests/Info.plist;
+				INFOPLIST_FILE = CommonsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jvpc.NetwrokingTests;
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.CommonsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
-		1A58F57F23367973002F459C /* Release */ = {
+		1A58F5A823367D01002F459C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 77FV36N6JL;
-				INFOPLIST_FILE = NetwrokingTests/Info.plist;
+				INFOPLIST_FILE = CommonsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jvpc.NetwrokingTests;
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.CommonsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -424,34 +424,34 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1A58F56023367973002F459C /* Build configuration list for PBXProject "Netwroking" */ = {
+		1A58F58923367D00002F459C /* Build configuration list for PBXProject "Commons" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1A58F57823367973002F459C /* Debug */,
-				1A58F57923367973002F459C /* Release */,
+				1A58F5A123367D01002F459C /* Debug */,
+				1A58F5A223367D01002F459C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1A58F57A23367973002F459C /* Build configuration list for PBXNativeTarget "Netwroking" */ = {
+		1A58F5A323367D01002F459C /* Build configuration list for PBXNativeTarget "Commons" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1A58F57B23367973002F459C /* Debug */,
-				1A58F57C23367973002F459C /* Release */,
+				1A58F5A423367D01002F459C /* Debug */,
+				1A58F5A523367D01002F459C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1A58F57D23367973002F459C /* Build configuration list for PBXNativeTarget "NetwrokingTests" */ = {
+		1A58F5A623367D01002F459C /* Build configuration list for PBXNativeTarget "CommonsTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1A58F57E23367973002F459C /* Debug */,
-				1A58F57F23367973002F459C /* Release */,
+				1A58F5A723367D01002F459C /* Debug */,
+				1A58F5A823367D01002F459C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 1A58F55D23367973002F459C /* Project object */;
+	rootObject = 1A58F58623367D00002F459C /* Project object */;
 }

--- a/Commons/Commons.xcodeproj/xcuserdata/josevictorpereiracosta.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Commons/Commons.xcodeproj/xcuserdata/josevictorpereiracosta.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>Commons.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Commons/Commons/Commons.h
+++ b/Commons/Commons/Commons.h
@@ -1,0 +1,19 @@
+//
+//  Commons.h
+//  Commons
+//
+//  Created by José Victor Pereira Costa on 21/09/19.
+//  Copyright © 2019 José Victor Pereira Costa. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Commons.
+FOUNDATION_EXPORT double CommonsVersionNumber;
+
+//! Project version string for Commons.
+FOUNDATION_EXPORT const unsigned char CommonsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Commons/PublicHeader.h>
+
+

--- a/Commons/Commons/Info.plist
+++ b/Commons/Commons/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Commons/CommonsTests/CommonsTests.swift
+++ b/Commons/CommonsTests/CommonsTests.swift
@@ -1,0 +1,34 @@
+//
+//  CommonsTests.swift
+//  CommonsTests
+//
+//  Created by José Victor Pereira Costa on 21/09/19.
+//  Copyright © 2019 José Victor Pereira Costa. All rights reserved.
+//
+
+import XCTest
+@testable import Commons
+
+class CommonsTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Commons/CommonsTests/Info.plist
+++ b/Commons/CommonsTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Netwroking/Networking.xcodeproj/project.pbxproj
+++ b/Netwroking/Networking.xcodeproj/project.pbxproj
@@ -1,0 +1,457 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1A58F57023367973002F459C /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58F56623367973002F459C /* Networking.framework */; };
+		1A58F57523367973002F459C /* NetwrokingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A58F57423367973002F459C /* NetwrokingTests.swift */; };
+		1A58F57723367973002F459C /* Netwroking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A58F56923367973002F459C /* Netwroking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1A58F57123367973002F459C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A58F55D23367973002F459C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A58F56523367973002F459C;
+			remoteInfo = Netwroking;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1A58F56623367973002F459C /* Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A58F56923367973002F459C /* Netwroking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Netwroking.h; sourceTree = "<group>"; };
+		1A58F56A23367973002F459C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A58F56F23367973002F459C /* NetworkingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NetworkingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A58F57423367973002F459C /* NetwrokingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetwrokingTests.swift; sourceTree = "<group>"; };
+		1A58F57623367973002F459C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1A58F56323367973002F459C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A58F56C23367973002F459C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A58F57023367973002F459C /* Networking.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1A58F55C23367973002F459C = {
+			isa = PBXGroup;
+			children = (
+				1A58F56823367973002F459C /* Netwroking */,
+				1A58F57323367973002F459C /* NetwrokingTests */,
+				1A58F56723367973002F459C /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1A58F56723367973002F459C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1A58F56623367973002F459C /* Networking.framework */,
+				1A58F56F23367973002F459C /* NetworkingTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1A58F56823367973002F459C /* Netwroking */ = {
+			isa = PBXGroup;
+			children = (
+				1A58F56923367973002F459C /* Netwroking.h */,
+				1A58F56A23367973002F459C /* Info.plist */,
+			);
+			path = Netwroking;
+			sourceTree = "<group>";
+		};
+		1A58F57323367973002F459C /* NetwrokingTests */ = {
+			isa = PBXGroup;
+			children = (
+				1A58F57423367973002F459C /* NetwrokingTests.swift */,
+				1A58F57623367973002F459C /* Info.plist */,
+			);
+			path = NetwrokingTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		1A58F56123367973002F459C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A58F57723367973002F459C /* Netwroking.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		1A58F56523367973002F459C /* Networking */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A58F57A23367973002F459C /* Build configuration list for PBXNativeTarget "Networking" */;
+			buildPhases = (
+				1A58F56123367973002F459C /* Headers */,
+				1A58F56223367973002F459C /* Sources */,
+				1A58F56323367973002F459C /* Frameworks */,
+				1A58F56423367973002F459C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Networking;
+			productName = Netwroking;
+			productReference = 1A58F56623367973002F459C /* Networking.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1A58F56E23367973002F459C /* NetworkingTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A58F57D23367973002F459C /* Build configuration list for PBXNativeTarget "NetworkingTests" */;
+			buildPhases = (
+				1A58F56B23367973002F459C /* Sources */,
+				1A58F56C23367973002F459C /* Frameworks */,
+				1A58F56D23367973002F459C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1A58F57223367973002F459C /* PBXTargetDependency */,
+			);
+			name = NetworkingTests;
+			productName = NetwrokingTests;
+			productReference = 1A58F56F23367973002F459C /* NetworkingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1A58F55D23367973002F459C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1100;
+				ORGANIZATIONNAME = "José Victor Pereira Costa";
+				TargetAttributes = {
+					1A58F56523367973002F459C = {
+						CreatedOnToolsVersion = 11.0;
+					};
+					1A58F56E23367973002F459C = {
+						CreatedOnToolsVersion = 11.0;
+					};
+				};
+			};
+			buildConfigurationList = 1A58F56023367973002F459C /* Build configuration list for PBXProject "Networking" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1A58F55C23367973002F459C;
+			productRefGroup = 1A58F56723367973002F459C /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1A58F56523367973002F459C /* Networking */,
+				1A58F56E23367973002F459C /* NetworkingTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1A58F56423367973002F459C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A58F56D23367973002F459C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1A58F56223367973002F459C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A58F56B23367973002F459C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A58F57523367973002F459C /* NetwrokingTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1A58F57223367973002F459C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A58F56523367973002F459C /* Networking */;
+			targetProxy = 1A58F57123367973002F459C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1A58F57823367973002F459C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		1A58F57923367973002F459C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		1A58F57B23367973002F459C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 77FV36N6JL;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Netwroking/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.Netwroking;
+				PRODUCT_NAME = Networking;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A58F57C23367973002F459C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 77FV36N6JL;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Netwroking/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.Netwroking;
+				PRODUCT_NAME = Networking;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		1A58F57E23367973002F459C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 77FV36N6JL;
+				INFOPLIST_FILE = NetwrokingTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.NetwrokingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A58F57F23367973002F459C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 77FV36N6JL;
+				INFOPLIST_FILE = NetwrokingTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = jvpc.NetwrokingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1A58F56023367973002F459C /* Build configuration list for PBXProject "Networking" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A58F57823367973002F459C /* Debug */,
+				1A58F57923367973002F459C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A58F57A23367973002F459C /* Build configuration list for PBXNativeTarget "Networking" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A58F57B23367973002F459C /* Debug */,
+				1A58F57C23367973002F459C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A58F57D23367973002F459C /* Build configuration list for PBXNativeTarget "NetworkingTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A58F57E23367973002F459C /* Debug */,
+				1A58F57F23367973002F459C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1A58F55D23367973002F459C /* Project object */;
+}

--- a/Netwroking/Networking.xcodeproj/xcuserdata/josevictorpereiracosta.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Netwroking/Networking.xcodeproj/xcuserdata/josevictorpereiracosta.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Netwroking.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>

--- a/QuizApp.xcodeproj/project.pbxproj
+++ b/QuizApp.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		1A0EB34F233657DC00D00D70 /* QuizAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0EB34E233657DC00D00D70 /* QuizAppUITests.swift */; };
 		1A58F5822336797F002F459C /* Netwroking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58F5812336797F002F459C /* Netwroking.framework */; };
 		1A58F5832336797F002F459C /* Netwroking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58F5812336797F002F459C /* Netwroking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1A58F5AA23367D0F002F459C /* Commons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58F5A923367D0F002F459C /* Commons.framework */; };
+		1A58F5AB23367D0F002F459C /* Commons.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58F5A923367D0F002F459C /* Commons.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +46,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				1A58F5832336797F002F459C /* Netwroking.framework in Embed Frameworks */,
+				1A58F5AB23367D0F002F459C /* Commons.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -66,6 +69,7 @@
 		1A0EB34E233657DC00D00D70 /* QuizAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizAppUITests.swift; sourceTree = "<group>"; };
 		1A0EB350233657DC00D00D70 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1A58F5812336797F002F459C /* Netwroking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Netwroking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A58F5A923367D0F002F459C /* Commons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Commons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +78,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A58F5822336797F002F459C /* Netwroking.framework in Frameworks */,
+				1A58F5AA23367D0F002F459C /* Commons.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -182,6 +187,7 @@
 		1A58F5802336797F002F459C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1A58F5A923367D0F002F459C /* Commons.framework */,
 				1A58F5812336797F002F459C /* Netwroking.framework */,
 			);
 			name = Frameworks;

--- a/QuizApp.xcworkspace/contents.xcworkspacedata
+++ b/QuizApp.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,10 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Netwroking/Netwroking.xcodeproj">
+      location = "group:Commons/Commons.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/josevictorpereiracosta/Documents/Tests/ArchTouch/QuizMobileApp/QuizApp/Netwroking/Networking.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:QuizApp.xcodeproj">


### PR DESCRIPTION
- Aiming to separate concerns and speed up build process, Commons target has been created.

- Fixing typing errors: Netwroking renamed to Networking.